### PR TITLE
Add new-signal check for DCA

### DIFF
--- a/EnhancedLSTMStrategy.py
+++ b/EnhancedLSTMStrategy.py
@@ -479,17 +479,22 @@ class EnhancedLSTMStrategy(IStrategy):
             dataframe, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
             if len(dataframe) < 20:
                 return None
-                
+
             # 获取当前信号强度
             current_signal = dataframe['&-target'].iloc[-1]
-            
-            # 检查信号方向是否与持仓一致
+            previous_signal = dataframe['&-target'].iloc[-2]
+
+            # 检查信号方向是否与持仓一致, 且为新的入场信号
             should_add_position = False
-            if trade.is_short and current_signal < -self.threshold_sell.value:
-                should_add_position = True
-            elif not trade.is_short and current_signal > self.threshold_buy.value:
-                should_add_position = True
-            
+            if trade.is_short:
+                if (current_signal < -self.threshold_sell.value and
+                        previous_signal >= -self.threshold_sell.value):
+                    should_add_position = True
+            else:
+                if (current_signal > self.threshold_buy.value and
+                        previous_signal <= self.threshold_buy.value):
+                    should_add_position = True
+
             if not should_add_position:
                 return None
                 


### PR DESCRIPTION
## Summary
- add position only when LSTM generates a new entry signal while trade is losing

## Testing
- `python -m py_compile EnhancedLSTMStrategy.py ExampleLSTMStrategy.py`


------
https://chatgpt.com/codex/tasks/task_e_68914e261c50832a9adf8feefc015fd9